### PR TITLE
Rewrites Location urls from BOSH since they don't include a port

### DIFF
--- a/bosh/export_release_test.go
+++ b/bosh/export_release_test.go
@@ -111,6 +111,7 @@ var _ = Describe("ExportRelease", func() {
 		Context("when the task status request fails", func() {
 			It("returns an error", func() {
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					w.Header().Set("Location", "%%%%")
 					w.WriteHeader(http.StatusFound)
 				}))
 
@@ -123,7 +124,7 @@ var _ = Describe("ExportRelease", func() {
 				_, err := client.ExportRelease("some-deployment-name",
 					"some-release-name", "some-release-version",
 					"some-stemcell-name", "some-stemcell-version")
-				Expect(err).To(MatchError(ContainSubstring("unsupported protocol scheme")))
+				Expect(err).To(MatchError(ContainSubstring("invalid URL escape")))
 			})
 		})
 


### PR DESCRIPTION
We've noticed the client breaks if BOSH does not provide a port with a redirect URL.

On a recent version of BOSH, it will respond with a Location header that looks like "https://your-bosh/tasks/1". This URL is missing the port that BOSH is responding on. Most HTTP clients will use the default port for the URL scheme, 443 in this case, and BOSH is not listening on that port. This means that the initial request will succeed, but the redirect request will fail.

This PR rewrites the Location header URL to include the correct scheme, host, and port as provided to the client.