### PR TITLE
Update turbulence client to send correct "Kill" request

### DIFF
--- a/turbulence/client.go
+++ b/turbulence/client.go
@@ -123,7 +123,7 @@ func (c Client) pollControlNetStarted(id string) (Response, error) {
 func (c Client) KillIDs(ids []string) error {
 	command := command{
 		Tasks: []interface{}{
-			killTask{Type: "kill"},
+			killTask{Type: "Kill"},
 		},
 		Selector: selector{
 			ID: id{

--- a/turbulence/client_test.go
+++ b/turbulence/client_test.go
@@ -13,7 +13,7 @@ import (
 
 const expectedKillPOSTRequest = `{
 	"Tasks": [{
-		"Type": "kill"
+		"Type": "Kill"
 	}],
 	"Selector": {
 		"ID": {


### PR DESCRIPTION
Turbulence api expects "Kill" not "kill"

Signed-off-by: Gaurab Dey <gdey@pivotal.io>