### PR TITLE
Ensures sever connections are closed for tests

### DIFF
--- a/bosh/cleanup_test.go
+++ b/bosh/cleanup_test.go
@@ -53,6 +53,10 @@ var _ = Describe("Cleanup", func() {
 		}))
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	It("cleans up the bosh director", func() {
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,

--- a/bosh/delete_deployment_test.go
+++ b/bosh/delete_deployment_test.go
@@ -48,6 +48,7 @@ var _ = Context("DeleteDeployment", func() {
 				Fail("could not match any URL endpoints")
 			}
 		}))
+		defer server.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:                 server.URL,
@@ -85,6 +86,7 @@ var _ = Context("DeleteDeployment", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -111,6 +113,7 @@ var _ = Context("DeleteDeployment", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -147,6 +150,7 @@ var _ = Context("DeleteDeployment", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -178,6 +182,7 @@ var _ = Context("DeleteDeployment", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -202,6 +207,7 @@ var _ = Context("DeleteDeployment", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -219,6 +225,7 @@ var _ = Context("DeleteDeployment", func() {
 				w.Header().Set("Location", fmt.Sprintf("http://%s/%%%%%%%%%%%%%%", r.Host))
 				w.WriteHeader(http.StatusFound)
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -257,6 +264,7 @@ var _ = Context("DeleteDeployment", func() {
 				w.WriteHeader(http.StatusFound)
 				w.Write([]byte(`&&%%%%%&%&%&%&%&%&%&%&`))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,

--- a/bosh/delete_release_test.go
+++ b/bosh/delete_release_test.go
@@ -51,6 +51,7 @@ var _ = Context("DeleteRelease", func() {
 				Fail(string(req))
 			}
 		}))
+		defer server.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:                 server.URL,
@@ -80,6 +81,7 @@ var _ = Context("DeleteRelease", func() {
 						Fail(string(req))
 					}
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:                 server.URL,
@@ -116,6 +118,7 @@ var _ = Context("DeleteRelease", func() {
 						Fail(string(req))
 					}
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:                 server.URL,

--- a/bosh/delete_stemcell_test.go
+++ b/bosh/delete_stemcell_test.go
@@ -46,6 +46,7 @@ var _ = Context("DeleteStemcell", func() {
 				Fail("could not match any URL endpoints")
 			}
 		}))
+		defer server.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:                 server.URL,
@@ -80,6 +81,7 @@ var _ = Context("DeleteStemcell", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -106,6 +108,7 @@ var _ = Context("DeleteStemcell", func() {
 						Fail("could not match any URL endpoints")
 					}
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:                 server.URL,
@@ -140,6 +143,7 @@ var _ = Context("DeleteStemcell", func() {
 						Fail("could not match any URL endpoints")
 					}
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:                 server.URL,

--- a/bosh/deploy_test.go
+++ b/bosh/deploy_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Deploy", func() {
 				Fail("could not match any URL endpoints")
 			}
 		}))
+		defer server.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:                 server.URL,
@@ -84,6 +85,7 @@ var _ = Describe("Deploy", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -110,6 +112,7 @@ var _ = Describe("Deploy", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: server.URL,
@@ -142,6 +145,7 @@ var _ = Describe("Deploy", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -170,6 +174,7 @@ var _ = Describe("Deploy", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -198,6 +203,7 @@ var _ = Describe("Deploy", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -229,6 +235,7 @@ var _ = Describe("Deploy", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -253,6 +260,7 @@ var _ = Describe("Deploy", func() {
 					Fail("could not match any URL endpoints")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -270,6 +278,7 @@ var _ = Describe("Deploy", func() {
 				w.Header().Set("Location", fmt.Sprintf("http://%s/%%%%%%%%%%%%%%", r.Host))
 				w.WriteHeader(http.StatusFound)
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -317,6 +326,7 @@ var _ = Describe("Deploy", func() {
 				w.WriteHeader(http.StatusFound)
 				w.Write([]byte(`&&%%%%%&%&%&%&%&%&%&%&`))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,

--- a/bosh/deployment_vms_test.go
+++ b/bosh/deployment_vms_test.go
@@ -56,6 +56,7 @@ var _ = Describe("DeploymentVMs", func() {
 				Fail("unknown route")
 			}
 		}))
+		defer server.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,
@@ -128,6 +129,7 @@ var _ = Describe("DeploymentVMs", func() {
 					Fail("unexpected route")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -145,6 +147,7 @@ var _ = Describe("DeploymentVMs", func() {
 				w.WriteHeader(http.StatusNotFound)
 				w.Write([]byte("More Info"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -162,6 +165,7 @@ var _ = Describe("DeploymentVMs", func() {
 				w.Header().Set("Location", "http://%%%%%/tasks/1")
 				w.WriteHeader(http.StatusFound)
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -179,6 +183,7 @@ var _ = Describe("DeploymentVMs", func() {
 				w.WriteHeader(http.StatusFound)
 				w.Write([]byte("%%%%%%\n%%%%%%%%%%%\n"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -204,6 +209,7 @@ var _ = Describe("DeploymentVMs", func() {
 					Fail("unexpected route")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -224,6 +230,7 @@ var _ = Describe("DeploymentVMs", func() {
 				w.WriteHeader(http.StatusNotFound)
 				w.Write([]byte("More Info"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,

--- a/bosh/deployments_test.go
+++ b/bosh/deployments_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Deployments", func() {
 				}
 			]`))
 		}))
+		defer server.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,
@@ -111,6 +112,7 @@ var _ = Describe("Deployments", func() {
 				w.WriteHeader(http.StatusBadGateway)
 				w.Write([]byte("More Info"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -126,6 +128,7 @@ var _ = Describe("Deployments", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(`%%%%%%%%`))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,

--- a/bosh/download_manifest_test.go
+++ b/bosh/download_manifest_test.go
@@ -30,6 +30,7 @@ var _ = Describe("DownloadManifest", func() {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"manifest": "some-manifest-contents"}`))
 		}))
+		defer testServer.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:      testServer.URL,
@@ -71,6 +72,7 @@ var _ = Describe("DownloadManifest", func() {
 				w.WriteHeader(http.StatusTeapot)
 				w.Write([]byte("More Info"))
 			}))
+			defer testServer.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: testServer.URL,
@@ -87,6 +89,7 @@ var _ = Describe("DownloadManifest", func() {
 				w.WriteHeader(http.StatusTeapot)
 				w.Write([]byte("More Info"))
 			}))
+			defer testServer.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: testServer.URL,
@@ -107,6 +110,7 @@ var _ = Describe("DownloadManifest", func() {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte("%%%%%%"))
 			}))
+			defer testServer.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: testServer.URL,

--- a/bosh/export_release_test.go
+++ b/bosh/export_release_test.go
@@ -67,6 +67,10 @@ var _ = Describe("ExportRelease", func() {
 		}))
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	It("exports the release and returns a resource ID for the release artifact", func() {
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,

--- a/bosh/get_task_output_test.go
+++ b/bosh/get_task_output_test.go
@@ -69,6 +69,10 @@ var _ = Describe("GetTaskOutput", func() {
 		))
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	Context("failure cases", func() {
 		It("error on a malformed URL", func() {
 			client := bosh.NewClient(bosh.Config{

--- a/bosh/info_test.go
+++ b/bosh/info_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Info", func() {
 
 			w.Write([]byte(`{"uuid":"some-director-uuid", "cpi":"some-cpi"}`))
 		}))
+		defer server.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:                 server.URL,
@@ -41,6 +42,7 @@ var _ = Describe("Info", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(`&&%%%%%&%&%&%&%&%&%&%&`))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -67,6 +69,7 @@ var _ = Describe("Info", func() {
 				w.WriteHeader(http.StatusBadGateway)
 				w.Write([]byte("More Info"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -83,6 +86,7 @@ var _ = Describe("Info", func() {
 				w.WriteHeader(http.StatusBadGateway)
 				w.Write([]byte("More Info"))
 			}))
+			defer testServer.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: testServer.URL,

--- a/bosh/locks_test.go
+++ b/bosh/locks_test.go
@@ -29,6 +29,7 @@ var _ = Describe("locks", func() {
 
 			w.Write([]byte(`[{"type":"deployment","resource":["some-deployment"],"timeout":"1475796348.793560"}]`))
 		}))
+		defer server.Close()
 
 		client = bosh.NewClient(bosh.Config{
 			URL:      server.URL,
@@ -60,6 +61,7 @@ var _ = Describe("locks", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				server.CloseClientConnections()
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: server.URL,
@@ -86,6 +88,7 @@ var _ = Describe("locks", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte("Some invalid JSON"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: server.URL,

--- a/bosh/release_test.go
+++ b/bosh/release_test.go
@@ -27,6 +27,7 @@ var _ = Describe("release", func() {
 
 				w.Write([]byte(`{"versions":["some-version","some-version.1","some-version.2"]}`))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -48,6 +49,7 @@ var _ = Describe("release", func() {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Write([]byte("More Info"))
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -65,6 +67,7 @@ var _ = Describe("release", func() {
 					Expect(r.URL.Path).To(Equal("/releases/some-release-name"))
 					w.WriteHeader(http.StatusNotFound)
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -92,6 +95,7 @@ var _ = Describe("release", func() {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.Write([]byte(`&&%%%%%&%&%&%&%&%&%&%&`))
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -120,6 +124,7 @@ var _ = Describe("release", func() {
 					w.WriteHeader(http.StatusTeapot)
 					w.Write([]byte("More info"))
 				}))
+				defer testServer.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL: testServer.URL,

--- a/bosh/resource_test.go
+++ b/bosh/resource_test.go
@@ -30,6 +30,10 @@ var _ = Describe("Resource", func() {
 		}))
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	It("returns the specified resource", func() {
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,

--- a/bosh/restart_test.go
+++ b/bosh/restart_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Restart", func() {
 					Fail("unexpected route")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -69,6 +70,8 @@ var _ = Describe("Restart", func() {
 					w.WriteHeader(http.StatusInternalServerError)
 					w.Write([]byte("something bad happened"))
 				}))
+				defer server.Close()
+
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
 					Username: "some-username",
@@ -106,6 +109,7 @@ var _ = Describe("Restart", func() {
 					w.Header().Set("Location", "%%%%%%%%%%%")
 					w.WriteHeader(http.StatusFound)
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -122,6 +126,7 @@ var _ = Describe("Restart", func() {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Write([]byte("More Info"))
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,

--- a/bosh/scan_and_fix_test.go
+++ b/bosh/scan_and_fix_test.go
@@ -59,6 +59,7 @@ var _ = Describe("ScanAndFix", func() {
 					Fail("unexpected route")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -118,6 +119,7 @@ var _ = Describe("ScanAndFix", func() {
 					Fail("unexpected route")
 				}
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:                 server.URL,
@@ -184,6 +186,7 @@ jobs:
 				w.Header().Set("Location", "%%%%%%%%%%%")
 				w.WriteHeader(http.StatusFound)
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -200,6 +203,7 @@ jobs:
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte("More Info"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -216,6 +220,7 @@ jobs:
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte("More Info"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,

--- a/bosh/stemcell_test.go
+++ b/bosh/stemcell_test.go
@@ -32,6 +32,7 @@ var _ = Describe("stemcell", func() {
 				]`))
 
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -53,6 +54,7 @@ var _ = Describe("stemcell", func() {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Write([]byte("More Info"))
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -70,6 +72,7 @@ var _ = Describe("stemcell", func() {
 					Expect(r.URL.Path).To(Equal("/stemcells"))
 					w.WriteHeader(http.StatusNotFound)
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -107,6 +110,7 @@ var _ = Describe("stemcell", func() {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.Write([]byte(`&&%%%%%&%&%&%&%&%&%&%&`))
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -125,6 +129,7 @@ var _ = Describe("stemcell", func() {
 					w.WriteHeader(http.StatusTeapot)
 					w.Write([]byte("More info"))
 				}))
+				defer testServer.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL: testServer.URL,
@@ -158,6 +163,7 @@ var _ = Describe("stemcell", func() {
 				]`))
 
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -179,6 +185,7 @@ var _ = Describe("stemcell", func() {
 					w.WriteHeader(http.StatusBadRequest)
 					w.Write([]byte("More Info"))
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -196,6 +203,7 @@ var _ = Describe("stemcell", func() {
 					Expect(r.URL.Path).To(Equal("/stemcells"))
 					w.WriteHeader(http.StatusNotFound)
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -233,6 +241,7 @@ var _ = Describe("stemcell", func() {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.Write([]byte(`&&%%%%%&%&%&%&%&%&%&%&`))
 				}))
+				defer server.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL:      server.URL,
@@ -251,6 +260,7 @@ var _ = Describe("stemcell", func() {
 					w.WriteHeader(http.StatusTeapot)
 					w.Write([]byte("More info"))
 				}))
+				defer testServer.Close()
 
 				client := bosh.NewClient(bosh.Config{
 					URL: testServer.URL,

--- a/bosh/task_result_test.go
+++ b/bosh/task_result_test.go
@@ -32,6 +32,10 @@ var _ = Describe("TaskResult", func() {
 		}))
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	It("fetches the result of a task", func() {
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,

--- a/bosh/update_cloud_config_test.go
+++ b/bosh/update_cloud_config_test.go
@@ -36,6 +36,7 @@ var _ = Describe("UpdateCloudConfig", func() {
 
 			w.WriteHeader(http.StatusCreated)
 		}))
+		defer testServer.Close()
 
 		client := bosh.NewClient(bosh.Config{
 			URL:      testServer.URL,
@@ -77,6 +78,7 @@ var _ = Describe("UpdateCloudConfig", func() {
 				w.WriteHeader(http.StatusTeapot)
 				w.Write([]byte("More info"))
 			}))
+			defer testServer.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: testServer.URL,
@@ -97,6 +99,7 @@ var _ = Describe("UpdateCloudConfig", func() {
 				w.WriteHeader(http.StatusTeapot)
 				w.Write([]byte("More info"))
 			}))
+			defer testServer.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL: testServer.URL,

--- a/bosh/upload_release_test.go
+++ b/bosh/upload_release_test.go
@@ -68,6 +68,10 @@ var _ = Describe("UploadRelease", func() {
 		}))
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	It("uploads the release to the director", func() {
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,

--- a/bosh/upload_stemcell_test.go
+++ b/bosh/upload_stemcell_test.go
@@ -51,6 +51,10 @@ var _ = Describe("UploadStemcell", func() {
 		}))
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	It("uploads the stemcell to the director", func() {
 		client := bosh.NewClient(bosh.Config{
 			URL:      server.URL,

--- a/bosh/vm_resurrection_test.go
+++ b/bosh/vm_resurrection_test.go
@@ -39,6 +39,7 @@ var _ = Describe("SetVMResurrection", func() {
 
 				w.WriteHeader(http.StatusTeapot)
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -78,6 +79,7 @@ var _ = Describe("SetVMResurrection", func() {
 				w.WriteHeader(http.StatusTeapot)
 				w.Write([]byte("something bad happened"))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,
@@ -94,6 +96,7 @@ var _ = Describe("SetVMResurrection", func() {
 				w.WriteHeader(http.StatusTeapot)
 				w.Write([]byte(""))
 			}))
+			defer server.Close()
 
 			client := bosh.NewClient(bosh.Config{
 				URL:      server.URL,


### PR DESCRIPTION
This fixes a `too many connections` error that was popping up when I was
running tests.

**Before**
```
Test Panicked
  httptest: failed to listen on a port: listen tcp6 [::1]:0: socket: too many open files
```

**After**
```
[1562262244] bosh - 149/149 specs ••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 38.554626ms PASS
[1562262244] turbulence - 10/10 specs •••••••••• SUCCESS! 404.543375ms PASS
```